### PR TITLE
Add build args for the new Kafka hosts

### DIFF
--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -5,7 +5,8 @@ FROM base as build
 
 COPY . .
 
-ARG PUBLIC_PROMPTU_API_HOST="http://localhost:8080"
+ARG PUBLIC_PROMPTU_POST_API_HOST="http://localhost:8080"
+ARG PUBLIC_PROMPTU_FEEDER_API_HOST="http://localhost:8081"
 
 RUN npm ci --only=production && \
     npm run build


### PR DESCRIPTION
When updating the env vars for the Kafka hosts, I forgot to include the env vars in the Dockerfile so they were never getting passed in. Need to think of a better way to manage this in future.