### PR TITLE
docs: point 3.9 should be after 4.2

### DIFF
--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -1,4 +1,4 @@
-app = "promptu-api"
+app = "promptu-api-isatest12"
 kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []

--- a/apps/ui/fly.toml
+++ b/apps/ui/fly.toml
@@ -1,4 +1,4 @@
-app = "promptu"
+app = "promptu-isatest12"
 kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []


### PR DESCRIPTION
The order for me to not get an error when setting up the secrets is 3.9 after changing the toml files.

It was erroring like this:
![Screenshot 2023-03-03 at 01 06 29](https://user-images.githubusercontent.com/11148726/222606027-01574bab-1dc4-4c76-ab72-0aa546858182.png)

After I've changed the toml files, it worked 🥳 
![Screenshot 2023-03-03 at 01 07 04](https://user-images.githubusercontent.com/11148726/222606023-92408008-6734-4996-8477-a786df786717.png)

@sansaid, feel free to change this! Also not sure what is the right branch